### PR TITLE
Add configurable request delay

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -6,7 +6,7 @@
 
 A personal data backup tool for Douban — One-click export of all your **movies, books, music, and games** records on Douban, including ratings, reviews, tags, and marking dates, output as beautifully formatted Excel and structured JSON.
 
-> v1.52 improves crawl reliability: account-isolated resumable backup, pagination completeness protection, response diagnostics, backup metadata, hardened Excel export, plus a richer CLI (verify / --only / --skip / --output / --no-resume) and broader test coverage.
+> v1.52 improves crawl reliability: account-isolated resumable backup, pagination completeness protection, response diagnostics, backup metadata, hardened Excel export, plus a richer CLI (verify / --only / --skip / --output / --delay / --no-resume) and broader test coverage.
 
 ---
 
@@ -41,7 +41,7 @@ A personal data backup tool for Douban — One-click export of all your **movies
 
 ### Anti-Crawling Strategies
 
-- 2-second smart request delay
+- **Configurable request delay** — use `--delay SECONDS` to adjust the wait between requests and reduce rate-limit risk (default: 2 seconds for authenticated backups, 1 second for public backups)
 - Automatic retry on failure (up to 3 times)
 - 30-second request timeout protection
 - Browser-level User-Agent spoofing
@@ -88,6 +88,9 @@ python main.py movies
 # Back up only Books
 python main.py books
 
+# Adjust the delay between requests (in seconds) to reduce rate-limit risk
+python main.py --delay 5
+
 # View historical backups
 python main.py list
 ```
@@ -107,6 +110,9 @@ data/backup/
 ```bash
 # Specify user ID via command-line argument
 python crawl_public.py <UserID>
+
+# Public backups support the same delay option
+python crawl_public.py <UserID> --delay 5
 
 # Or run directly for interactive input
 python crawl_public.py

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 豆瓣个人数据备份工具 — 一键导出你在豆瓣上的 **电影、书籍、音乐、游戏** 全部记录，包括评分、评语、标签和标记日期，输出为精美 Excel 和结构化 JSON。
 
-> v1.52 提升了抓取可靠性：加入账号隔离的断点恢复、分页完整性保护、响应诊断、备份元数据、导出安全加固，并完善命令行（verify / --only / --skip / --output / --no-resume）与测试覆盖。
+> v1.52 提升了抓取可靠性：加入账号隔离的断点恢复、分页完整性保护、响应诊断、备份元数据、导出安全加固，并完善命令行（verify / --only / --skip / --output / --delay / --no-resume）与测试覆盖。
 
 ---
 
@@ -41,7 +41,7 @@
 
 ### 防反爬策略
 
-- 请求间隔 2 秒智能延迟
+- **可配置请求间隔** — 使用 `--delay 秒数` 调整每次请求之间的等待时间，降低访问过快被限制的风险（登录备份默认 2 秒，公开备份默认 1 秒）
 - 失败自动重试（最多 3 次）
 - 30 秒请求超时保护
 - 浏览器级 User-Agent 伪装
@@ -103,6 +103,9 @@ python main.py list
 # 自由选择或排除分类
 python main.py --only movies,books
 python main.py --skip music,games
+
+# 调整每次请求之间的等待时间（秒），降低访问过快被限制的风险
+python main.py --delay 5
 ```
 
 ### 4. 查看结果
@@ -138,11 +141,17 @@ JSON 文件使用统一的顶层结构：
 # 通过命令行参数指定用户 ID
 python crawl_public.py <用户ID>
 
+# 公开数据备份同样支持请求间隔
+python crawl_public.py <用户ID> --delay 5
+
 # 或直接运行，交互式输入
 python crawl_public.py
 
 # 也可通过统一入口选择分类和输出目录
 python main.py --public <用户ID> --only movies,books --output D:\douban-backup
+
+# 统一入口的公开数据模式
+python main.py --public <用户ID> --delay 5
 ```
 
 ---

--- a/base.py
+++ b/base.py
@@ -15,18 +15,27 @@ class BaseCrawler:
     PAGE_SIZE = 15
     RETRYABLE_RESPONSE_CODES = {"rate_limited", "server_error"}
 
-    def __init__(self, session, category_key=None, state_store=None):
+    def __init__(
+        self,
+        session,
+        category_key=None,
+        state_store=None,
+        request_delay=DELAY_BETWEEN_REQUESTS,
+    ):
         self.session = session
         self.data = []
         self.category_key = category_key
         self.state_store = state_store
+        self.request_delay = (
+            DELAY_BETWEEN_REQUESTS if request_delay is None else request_delay
+        )
         self.incomplete = False
 
     def _make_request(self, url, retries=MAX_RETRIES):
         """发起HTTP请求，带重试机制"""
         for i in range(retries):
             try:
-                time.sleep(DELAY_BETWEEN_REQUESTS)
+                time.sleep(self.request_delay)
                 response = self.session.get(url, timeout=REQUEST_TIMEOUT)
                 status, code, message = classify_response(response)
                 if status == "ok" or code not in self.RETRYABLE_RESPONSE_CODES:

--- a/crawl_public.py
+++ b/crawl_public.py
@@ -7,6 +7,7 @@ import os
 import re
 import time
 import sys
+import argparse
 import requests
 from bs4 import BeautifulSoup
 from openpyxl import Workbook
@@ -32,6 +33,7 @@ DEFAULT_OUTPUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'd
 OUTPUT_DIR = DEFAULT_OUTPUT_DIR
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 DEFAULT_CATEGORIES = ['movies', 'books', 'music', 'games']
+DEFAULT_REQUEST_DELAY = 1
 
 
 def get_comment(item):
@@ -40,7 +42,7 @@ def get_comment(item):
     return comment_tag.get_text(' ', strip=True) if comment_tag else ''
 
 
-def crawl_movies():
+def crawl_movies(request_delay=DEFAULT_REQUEST_DELAY):
     """爬取电影数据"""
     print("\n[电影] 爬取电影数据...")
     all_movies = {'wish': [], 'collect': [], 'do': []}
@@ -87,7 +89,7 @@ def crawl_movies():
                     break
 
                 page += 1
-                time.sleep(1)
+                time.sleep(request_delay)
 
             except Exception as e:
                 print(f"    错误: {e}")
@@ -153,7 +155,7 @@ def parse_movie_item(item):
         return None
 
 
-def crawl_books():
+def crawl_books(request_delay=DEFAULT_REQUEST_DELAY):
     """爬取书籍数据"""
     print("\n[书籍] 爬取书籍数据...")
     all_books = {'wish': [], 'collect': [], 'reading': []}
@@ -206,7 +208,7 @@ def crawl_books():
                     break
 
                 page += 1
-                time.sleep(1)
+                time.sleep(request_delay)
 
             except Exception as e:
                 print(f"    错误: {e}")
@@ -286,7 +288,7 @@ def parse_book_item(item):
         return None
 
 
-def crawl_music():
+def crawl_music(request_delay=DEFAULT_REQUEST_DELAY):
     """爬取音乐数据"""
     print("\n[音乐] 爬取音乐数据...")
     all_music = {'wish': [], 'collect': [], 'do': []}
@@ -333,7 +335,7 @@ def crawl_music():
                     break
 
                 page += 1
-                time.sleep(1)
+                time.sleep(request_delay)
 
             except Exception as e:
                 print(f"    错误: {e}")
@@ -395,7 +397,7 @@ def parse_music_item(item):
         return None
 
 
-def crawl_games():
+def crawl_games(request_delay=DEFAULT_REQUEST_DELAY):
     """爬取游戏数据"""
     print("\n[游戏] 爬取游戏数据...")
     all_games = {'wish': [], 'collect': [], 'do': []}
@@ -442,7 +444,7 @@ def crawl_games():
                     break
 
                 page += 1
-                time.sleep(1)
+                time.sleep(request_delay)
 
             except Exception as e:
                 print(f"    错误: {e}")
@@ -564,7 +566,7 @@ def save_excel(data, filename, metadata=None):
     return filepath
 
 
-def run_public_backup(user_id, categories=None, output_dir=None):
+def run_public_backup(user_id, categories=None, output_dir=None, request_delay=None):
     global USER_ID, OUTPUT_DIR
 
     USER_ID = user_id
@@ -572,6 +574,9 @@ def run_public_backup(user_id, categories=None, output_dir=None):
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 
     categories = list(categories or DEFAULT_CATEGORIES)
+    request_delay = (
+        DEFAULT_REQUEST_DELAY if request_delay is None else request_delay
+    )
     metadata = build_metadata(
         backup_mode='public',
         selected_categories=categories,
@@ -597,7 +602,7 @@ def run_public_backup(user_id, categories=None, output_dir=None):
 
     try:
         for category in categories:
-            category_data = crawlers[category]()
+            category_data = crawlers[category](request_delay=request_delay)
             all_data[category] = category_data
             save_json(
                 category_data,
@@ -641,22 +646,44 @@ def run_public_backup(user_id, categories=None, output_dir=None):
         return all_data
 
 
-def main():
-    global USER_ID
+def non_negative_delay(raw_value):
+    try:
+        delay = float(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("间隔时间必须是数字。") from error
+    if delay < 0:
+        raise argparse.ArgumentTypeError("间隔时间不能小于 0。")
+    return delay
 
-    if len(sys.argv) > 1:
-        USER_ID = sys.argv[1]
-    else:
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="豆瓣公开数据备份工具")
+    parser.add_argument("user_id", nargs="?", help="豆瓣用户 ID")
+    parser.add_argument(
+        "--delay",
+        type=non_negative_delay,
+        metavar="SECONDS",
+        help="每次请求之间等待的秒数，默认 1 秒",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    user_id = args.user_id
+
+    if not user_id:
         USER_ID = input("请输入豆瓣用户ID: ").strip()
         if not USER_ID:
             print("用户ID不能为空!")
-            print("用法: python crawl_public.py <用户ID>")
+            print("用法: python crawl_public.py <用户ID> [--delay 秒数]")
             return
+        user_id = USER_ID
 
     print("=" * 50)
     print("[豆瓣数据备份工具]")
     print("=" * 50)
-    run_public_backup(USER_ID)
+    run_public_backup(user_id, request_delay=args.delay)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -37,6 +37,16 @@ def parse_category_list(raw_value):
     return [item.strip() for item in raw_value.split(",") if item.strip()]
 
 
+def non_negative_delay(raw_value):
+    try:
+        delay = float(raw_value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("间隔时间必须是数字。") from error
+    if delay < 0:
+        raise argparse.ArgumentTypeError("间隔时间不能小于 0。")
+    return delay
+
+
 def resolve_selected_items(only=None, skip=None):
     if only:
         selected = parse_category_list(only)
@@ -71,17 +81,30 @@ def parse_args(argv=None):
     parser.add_argument("--skip", help="跳过指定分类，逗号分隔，例如 music,games")
     parser.add_argument("--public", metavar="USER_ID", help="使用公开页面模式备份指定用户")
     parser.add_argument("--output", help="导出目录，默认使用 data/backup")
+    parser.add_argument(
+        "--delay",
+        type=non_negative_delay,
+        metavar="SECONDS",
+        help="每次请求之间等待的秒数；默认登录备份为 2 秒，公开备份为 1 秒",
+    )
     parser.add_argument("--no-resume", action="store_true", help="禁用断点续传")
     return parser.parse_args(argv)
 
 
 class DoubanBackup:
-    def __init__(self, selected_items=None, output_dir=None, checkpoint_enabled=True):
+    def __init__(
+        self,
+        selected_items=None,
+        output_dir=None,
+        checkpoint_enabled=True,
+        request_delay=None,
+    ):
         self.auth = DoubanAuth()
         self.selected_items = list(selected_items or VALID_CATEGORIES)
         self.output_dir = output_dir
         self.storage = DataStorage(backup_dir=output_dir)
         self.checkpoint_enabled = checkpoint_enabled
+        self.request_delay = request_delay
         self.state_store = None
         self.session = None
         self.user_id = None
@@ -260,28 +283,44 @@ class DoubanBackup:
 
         if "movies" in self.selected_items:
             print("\n[电影] 备份电影...")
-            movie_crawler = MovieCrawler(self.session, state_store=self.state_store)
+            movie_crawler = MovieCrawler(
+                self.session,
+                state_store=self.state_store,
+                request_delay=self.request_delay,
+            )
             movie_crawler.set_user_id(self.user_id)
             all_data["movies"] = movie_crawler.crawl_all_movies()
             self.backup_incomplete |= movie_crawler.incomplete
 
         if "books" in self.selected_items:
             print("\n[书籍] 备份书籍...")
-            book_crawler = BookCrawler(self.session, state_store=self.state_store)
+            book_crawler = BookCrawler(
+                self.session,
+                state_store=self.state_store,
+                request_delay=self.request_delay,
+            )
             book_crawler.set_user_id(self.user_id)
             all_data["books"] = book_crawler.crawl_all_books()
             self.backup_incomplete |= book_crawler.incomplete
 
         if "music" in self.selected_items:
             print("\n[音乐] 备份音乐...")
-            music_crawler = MusicCrawler(self.session, state_store=self.state_store)
+            music_crawler = MusicCrawler(
+                self.session,
+                state_store=self.state_store,
+                request_delay=self.request_delay,
+            )
             music_crawler.set_user_id(self.user_id)
             all_data["music"] = music_crawler.crawl_all_music()
             self.backup_incomplete |= music_crawler.incomplete
 
         if "games" in self.selected_items:
             print("\n[游戏] 备份游戏...")
-            game_crawler = GameCrawler(self.session, state_store=self.state_store)
+            game_crawler = GameCrawler(
+                self.session,
+                state_store=self.state_store,
+                request_delay=self.request_delay,
+            )
             game_crawler.set_user_id(self.user_id)
             all_data["games"] = game_crawler.crawl_all_games()
             self.backup_incomplete |= game_crawler.incomplete
@@ -313,7 +352,11 @@ class DoubanBackup:
         }[category]
 
         self._prepare_storage("authenticated", [category])
-        crawler = crawler_class(self.session, state_store=self.state_store)
+        crawler = crawler_class(
+            self.session,
+            state_store=self.state_store,
+            request_delay=self.request_delay,
+        )
         crawler.set_user_id(self.user_id)
         category_data = getattr(crawler, crawl_method)()
         data = {category: category_data}
@@ -351,12 +394,14 @@ def main(argv=None):
             args.public,
             categories=selected_items,
             output_dir=args.output,
+            request_delay=args.delay,
         )
 
     backup = DoubanBackup(
         selected_items=selected_items,
         output_dir=args.output,
         checkpoint_enabled=not args.no_resume,
+        request_delay=args.delay,
     )
 
     if args.command == "verify":

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -28,6 +28,18 @@ class DummyCrawler(BaseCrawler):
 
 class BaseCrawlerTests(unittest.TestCase):
     @patch("base.time.sleep")
+    def test_uses_configured_request_delay(self, sleep):
+        session = Mock()
+        response = DummyResponse()
+        session.get.return_value = response
+        crawler = DummyCrawler(session)
+        crawler.request_delay = 4.5
+
+        self.assertIs(crawler._make_request("https://example.test/delayed"), response)
+
+        sleep.assert_called_once_with(4.5)
+
+    @patch("base.time.sleep")
     def test_not_found_response_is_not_retried(self, _sleep):
         session = Mock()
         response = DummyResponse(status_code=404)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,31 @@ class CliDispatchTests(unittest.TestCase):
             "demo-user",
             categories=["movies"],
             output_dir="D:\\exports",
+            request_delay=None,
+        )
+
+    def test_main_passes_custom_request_delay_to_backup(self):
+        with patch("main.DoubanBackup") as backup_cls:
+            instance = backup_cls.return_value
+            main.main(["--delay", "4.5"])
+
+        backup_cls.assert_called_once_with(
+            selected_items=["movies", "books", "music", "games"],
+            output_dir=None,
+            checkpoint_enabled=True,
+            request_delay=4.5,
+        )
+        instance.run.assert_called_once()
+
+    def test_main_passes_custom_request_delay_to_public_backup(self):
+        with patch("main.run_public_backup") as run_public:
+            main.main(["--public", "demo-user", "--delay", "3"])
+
+        run_public.assert_called_once_with(
+            "demo-user",
+            categories=["movies", "books", "music", "games"],
+            output_dir=None,
+            request_delay=3.0,
         )
 
 

--- a/tests/test_crawl_public.py
+++ b/tests/test_crawl_public.py
@@ -70,6 +70,12 @@ class CrawlPublicTests(unittest.TestCase):
             urls,
         )
 
+    def test_standalone_cli_passes_request_delay(self):
+        with patch.object(crawl_public, "run_public_backup") as run_public:
+            crawl_public.main(["demo-user", "--delay", "2.5"])
+
+        run_public.assert_called_once_with("demo-user", request_delay=2.5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed
- Added a `--delay SECONDS` option to authenticated and public backup commands.
- Applied the selected delay between requests while preserving the existing defaults.
- Added homepage and usage documentation in Chinese and English.
- Added coverage for command-line delay forwarding.

## Why
A configurable delay helps reduce the risk of rate limiting during record extraction.

## Validation
- `python -m unittest discover -s tests -v` (37 tests passed)
- `git diff --check`