### PR TITLE
Release version 1.53

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -1,12 +1,12 @@
 # Douban Backup
 
-[![v1.52](https://img.shields.io/badge/version-1.52-blue.svg)](https://github.com/zx2592/douban_backup)
+[![v1.53](https://img.shields.io/badge/version-1.53-blue.svg)](https://github.com/zx2592/douban_backup)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-green.svg)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 
 A personal data backup tool for Douban — One-click export of all your **movies, books, music, and games** records on Douban, including ratings, reviews, tags, and marking dates, output as beautifully formatted Excel and structured JSON.
 
-> v1.52 improves crawl reliability: account-isolated resumable backup, pagination completeness protection, response diagnostics, backup metadata, hardened Excel export, plus a richer CLI (verify / --only / --skip / --output / --delay / --no-resume) and broader test coverage.
+> v1.53 adds configurable request delays: use `--delay SECONDS` to pace crawling and reduce rate-limit risk.
 
 ---
 
@@ -144,6 +144,10 @@ python crawl_public.py
 ---
 
 ## Changelog
+
+### v1.53 — Configurable Request Delay
+
+- **Reduced rate-limit risk** — Authenticated and public backups now accept `--delay SECONDS` to control the wait between requests; their defaults remain 2 seconds and 1 second respectively
 
 ### v1.52 — Reliability & CLI Enhancements
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Douban Backup
 
-[![v1.52](https://img.shields.io/badge/version-1.52-blue.svg)](https://github.com/zx2592/douban_backup)
+[![v1.53](https://img.shields.io/badge/version-1.53-blue.svg)](https://github.com/zx2592/douban_backup)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-green.svg)](https://www.python.org)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](LICENSE)
 
 豆瓣个人数据备份工具 — 一键导出你在豆瓣上的 **电影、书籍、音乐、游戏** 全部记录，包括评分、评语、标签和标记日期，输出为精美 Excel 和结构化 JSON。
 
-> v1.52 提升了抓取可靠性：加入账号隔离的断点恢复、分页完整性保护、响应诊断、备份元数据、导出安全加固，并完善命令行（verify / --only / --skip / --output / --delay / --no-resume）与测试覆盖。
+> v1.53 新增可配置请求间隔：使用 `--delay 秒数` 调整抓取节奏，降低访问过快被限制的风险。
 
 ---
 
@@ -124,7 +124,7 @@ JSON 文件使用统一的顶层结构：
 ```json
 {
   "metadata": {
-    "app_version": "1.52",
+    "app_version": "1.53",
     "backup_mode": "authenticated",
     "generated_at": "2026-08-06T20:00:00-07:00",
     "selected_categories": ["movies", "books"]
@@ -186,6 +186,10 @@ python main.py --public <用户ID> --delay 5
 ---
 
 ## 更新日志
+
+### v1.53 — 可配置请求间隔
+
+- **降低访问限制风险** — 登录和公开数据备份均支持 `--delay 秒数`，可按需调整每次请求之间的等待时间；默认分别为 2 秒和 1 秒
 
 ### v1.52 — 可靠性与命令行增强
 

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@
 import os
 
 DOUBAN_BASE_URL = 'https://www.douban.com'
-APP_VERSION = '1.52'
+APP_VERSION = '1.53'
 
 HEADERS = {
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',


### PR DESCRIPTION
## What changed
- Bumped the application version to 1.53.
- Updated Chinese and English homepage badges and release summaries.
- Added v1.53 changelog entries for configurable request delays.

## Why
The configurable `--delay` feature has been released and needs accurate version and homepage documentation.

## Validation
- `python -m unittest discover -s tests -v` (37 tests passed)
- `git diff --check`